### PR TITLE
Use onlyOn* pest methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "pestphp/pest": "^2.24.3",
+        "pestphp/pest": "^2.25",
         "pestphp/pest-plugin": "^2.1.1",
         "ext-curl": "*",
         "ext-zip": "*"

--- a/tests/Unit/K6.php
+++ b/tests/Unit/K6.php
@@ -10,7 +10,7 @@ it('infers the path from the environment on mac OS', function (): void {
     $arch = str_contains(php_uname('m'), 'arm') ? 'arm64' : 'amd64';
 
     expect((string) $binary)->toBe(realpath(__DIR__.'/../../bin/k6-'.k6::K6_VERSION.'-macos-'.$arch.'/k6'));
-})->skipOnLinux()->skipOnWindows();
+})->onlyOnMac();
 
 it('infers the path from the environment on Linux', function (): void {
     $binary = K6::make();
@@ -18,7 +18,7 @@ it('infers the path from the environment on Linux', function (): void {
     $arch = str_contains(php_uname('m'), 'arm') ? 'arm64' : 'amd64';
 
     expect((string) $binary)->toBe(realpath(__DIR__.'/../../bin/k6-'.k6::K6_VERSION.'-linux-'.$arch.'/k6'));
-})->skipOnMac()->skipOnWindows();
+})->onlyOnLinux();
 
 it('infers the path from the environment on Windows', function (): void {
     $binary = K6::make();
@@ -26,4 +26,4 @@ it('infers the path from the environment on Windows', function (): void {
     $arch = 'amd64'; // Always amd64 on windows
 
     expect((string) $binary)->toBe(realpath(__DIR__.'/../../bin/k6-'.k6::K6_VERSION.'-windows-'.$arch.'/k6.exe'));
-})->skipOnMac()->skipOnLinux();
+})->onlyOnWindows();


### PR DESCRIPTION
This PR introduces the use of the new onlyOn* pest methods to skip tests on specific OSes