### PR TITLE
[2.x] Adds the `stress` function for declaring stress tests

### DIFF
--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -4,7 +4,25 @@ declare(strict_types=1);
 
 namespace Pest\Stressless;
 
-function stress(string $url): Factory
+use Closure;
+use Pest\PendingCalls\TestCall;
+
+/**
+ * If passed two parameters, this function creates a test
+ * with the `stress` group. If only passed one parameter,
+ * it will perform a stress test on the given URL.
+ */
+function stress(string $description, ?Closure $test = null): Factory|TestCall
+{
+    return func_num_args() > 1
+        ? test($description, func_get_arg(1))->group('stress')
+        : visit($description);
+}
+
+/**
+ * Performs a stress test on the given URL.
+ */
+function visit(string $url): Factory
 {
     return Factory::make($url);
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -28,6 +28,14 @@ final class Plugin implements HandlesArguments
      */
     public function handleArguments(array $arguments): array
     {
+        if ($this->hasArgument('--stress', $arguments)) {
+            return $this->pushArgument('--group=stress', $this->popArgument('--stress', $arguments));
+        }
+
+        if ($this->hasArgument('--exclude-stress', $arguments)) {
+            return $this->pushArgument('--exclude-group=stress', $this->popArgument('--exclude-stress', $arguments));
+        }
+
         if (! array_key_exists(1, $arguments)) {
             return $arguments;
         }

--- a/tests/Feature/StressTestFunction.php
+++ b/tests/Feature/StressTestFunction.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use function Pest\Stressless\stress;
+
+stress('the homepage', function (): void {
+    stress('example.com');
+
+    expect(test()->groups()[0])->toBe('stress');
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use function Pest\Stressless\stress;
+use function Pest\Stressless\visit;
 
 uses()->beforeEach(function (): void {
-    $this->stress = $_SERVER['stress'] ??= stress('example.com')
+    $this->stress = $_SERVER['stress'] ??= visit('example.com')
         ->concurrently(2)
         ->for(1)->second();
 

--- a/tests/Unit/Factory.php
+++ b/tests/Unit/Factory.php
@@ -2,71 +2,73 @@
 
 declare(strict_types=1);
 
-it('correctly use get method by default', function (): void {
+use function Pest\Stressless\stress;
+
+stress('correctly use get method by default', function (): void {
     expect($this->stress->method())->toBe('get');
 });
 
-it('correctly sets the delete method', function (): void {
+stress('correctly sets the delete method', function (): void {
     $this->stress->delete();
 
     expect($this->stress->method())->toBe('delete');
 });
 
-it('correctly sets the get method', function (): void {
+stress('correctly sets the get method', function (): void {
     $this->stress->get();
 
     expect($this->stress->method())->toBe('get');
 });
 
-it('correctly sets the head method', function (): void {
+stress('correctly sets the head method', function (): void {
     $this->stress->head();
 
     expect($this->stress->method())->toBe('head');
 });
 
-it('correctly sets the options method without payload', function (): void {
+stress('correctly sets the options method without payload', function (): void {
     $this->stress->options();
 
     expect($this->stress->method())->toBe('options')
         ->and($this->stress->payload())->toBe([]);
 });
 
-it('correctly sets the options method with payload', function (): void {
+stress('correctly sets the options method with payload', function (): void {
     $this->stress->options(['foo' => 'bar']);
 
     expect($this->stress->method())->toBe('options')
         ->and($this->stress->payload())->toBe(['foo' => 'bar']);
 });
 
-it('correctly sets the patch method without payload', function (): void {
+stress('correctly sets the patch method without payload', function (): void {
     $this->stress->patch();
 
     expect($this->stress->method())->toBe('patch')
         ->and($this->stress->payload())->toBe([]);
 });
 
-it('correctly sets the patch method with payload', function (): void {
+stress('correctly sets the patch method with payload', function (): void {
     $this->stress->patch(['foo' => 'bar']);
 
     expect($this->stress->method())->toBe('patch')
         ->and($this->stress->payload())->toBe(['foo' => 'bar']);
 });
 
-it('correctly sets the put method without payload', function (): void {
+stress('correctly sets the put method without payload', function (): void {
     $this->stress->put();
 
     expect($this->stress->method())->toBe('put')
         ->and($this->stress->payload())->toBe([]);
 });
 
-it('correctly sets the put method with payload', function (): void {
+stress('correctly sets the put method with payload', function (): void {
     $this->stress->put(['foo' => 'bar']);
 
     expect($this->stress->method())->toBe('put')
         ->and($this->stress->payload())->toBe(['foo' => 'bar']);
 });
 
-it('correctly sets the post method', function (): void {
+stress('correctly sets the post method', function (): void {
     $this->stress->post(['foo' => 'bar']);
 
     expect($this->stress->method())->toBe('post')


### PR DESCRIPTION
Much like the PR to the Arch plugin, this PR adds the `stress` function as a top level test creator that also marks the test as being part of the `stress` group, allowing the user (and Pest) to easily only run stress tests or exclude stress tests.

The problem with this plugin is that we already declare the `stress` function to start a stress test. I handle this in the following way:

- `stress` now accepts two parameters. If only one is passed, it acts as it did before. If both are passed, it acts as a `test` function.
- A new function has been added, `visit`, which performs the same functionality that `stress` did previously. The `stress` function now calls `visit` under the hood.

My hope is that we can encourage users to make use of `visit` instead of `stress` inside the test closure itself, although obviously what I've added here is still fully backwards compatible. Obviously I'm also open to other approaches here.

Kind Regards,
Luke