### PR TITLE
Don't use JSON.stringify to pass payload to k6/Http

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -26,22 +26,22 @@ export default () => {
             });
             break;
         case 'options':
-            http.options(url, Object.keys(payload).length ? JSON.stringify(payload) : null, {
+            http.options(url, Object.keys(payload).length ? payload : null, {
                 headers: { 'user-agent': userAgent },
             });
             break;
         case 'patch':
-            http.patch(url, Object.keys(payload).length ? JSON.stringify(payload) : null, {
+            http.patch(url, Object.keys(payload).length ? payload : null, {
                 headers: { 'user-agent': userAgent },
             });
             break;
         case 'put':
-            http.put(url, Object.keys(payload).length ? JSON.stringify(payload) : null, {
+            http.put(url, Object.keys(payload).length ? payload : null, {
                 headers: { 'user-agent': userAgent },
             });
             break;
         case 'post':
-            http.post(url, JSON.stringify(payload), {
+            http.post(url, payload, {
                 headers: { 'user-agent': userAgent },
             });
             break;


### PR DESCRIPTION
As per the [the documentation](https://grafana.com/docs/k6/latest/javascript-api/k6-http/post/) we should either:
- Specify the application/json content type header
- Pass an object (the header will be automatically set to application/x-www-form-urlencoded)