### PR TITLE
Add application/json content type header

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -27,22 +27,22 @@ export default () => {
             break;
         case 'options':
             http.options(url, Object.keys(payload).length ? JSON.stringify(payload) : null, {
-                headers: { 'user-agent': userAgent },
+                headers: { 'Content-Type': 'application/json', 'user-agent': userAgent },
             });
             break;
         case 'patch':
             http.patch(url, Object.keys(payload).length ? JSON.stringify(payload) : null, {
-                headers: { 'user-agent': userAgent },
+                headers: { 'Content-Type': 'application/json', 'user-agent': userAgent },
             });
             break;
         case 'put':
             http.put(url, Object.keys(payload).length ? JSON.stringify(payload) : null, {
-                headers: { 'user-agent': userAgent },
+                headers: { 'Content-Type': 'application/json', 'user-agent': userAgent },
             });
             break;
         case 'post':
             http.post(url, JSON.stringify(payload), {
-                headers: { 'user-agent': userAgent },
+                headers: { 'Content-Type': 'application/json', 'user-agent': userAgent },
             });
             break;
     }


### PR DESCRIPTION
As per the the [documentation](https://grafana.com/docs/k6/latest/javascript-api/k6-http/post/) we should specify the application/json content type header.