### PR TITLE
[3.x] Add custom headers to requests

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -9,40 +9,44 @@ export default () => {
     let payload = options.payload ? options.payload : {};
     let method = options.method ? options.method : 'get';
 
+    let headers = options.headers ? options.headers : {}
+
+    headers['user-agent'] = userAgent;
+
     switch (method) {
         case 'delete':
             http.del(url, null, {
-                headers: { 'user-agent': userAgent },
+                headers,
             });
             break;
         case 'get':
             http.get(url, {
-                headers: { 'user-agent': userAgent },
+                headers,
             });
             break;
         case 'head':
             http.head(url, {
-                headers: { 'user-agent': userAgent },
+                headers,
             });
             break;
         case 'options':
             http.options(url, Object.keys(payload).length ? JSON.stringify(payload) : null, {
-                headers: { 'user-agent': userAgent },
+                headers,
             });
             break;
         case 'patch':
             http.patch(url, Object.keys(payload).length ? JSON.stringify(payload) : null, {
-                headers: { 'user-agent': userAgent },
+                headers,
             });
             break;
         case 'put':
             http.put(url, Object.keys(payload).length ? JSON.stringify(payload) : null, {
-                headers: { 'user-agent': userAgent },
+                headers,
             });
             break;
         case 'post':
             http.post(url, JSON.stringify(payload), {
-                headers: { 'user-agent': userAgent },
+                headers,
             });
             break;
     }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -39,6 +39,13 @@ final class Factory
     private array $payload = [];
 
     /**
+     * The headers to send.
+     *
+     * @var array<string, string>
+     */
+    private array $headers = [];
+
+    /**
      * The computed result, if any.
      */
     private ?Result $result = null;
@@ -67,6 +74,18 @@ final class Factory
         assert($seconds > 0, 'The duration must be greater than 0 seconds.');
 
         $this->duration = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * Specifies the headers to send with the request.
+     *
+     * @param  array<string, string>  $headers
+     */
+    public function headers(array $headers): self
+    {
+        $this->headers = $headers;
 
         return $this;
     }
@@ -215,6 +234,7 @@ final class Factory
                 'duration' => sprintf('%ds', $this->duration),
                 'method' => $this->method,
                 'payload' => $this->payload,
+                'headers' => $this->headers,
                 'throw' => true,
             ],
             $this->verbose,

--- a/tests/Unit/Factory.php
+++ b/tests/Unit/Factory.php
@@ -72,3 +72,16 @@ it('correctly sets the post method', function (): void {
     expect($this->stress->method())->toBe('post')
         ->and($this->stress->payload())->toBe(['foo' => 'bar']);
 });
+
+it('correctly sets the headers', function (): void {
+    $this->stress->headers(['foo' => 'bar']);
+
+    $class = new \ReflectionClass($this->stress);
+    $protected = $class->getProperty('headers');
+    $protected->setAccessible(true);
+
+    $instance = $this->stress;
+    $headers = $protected->getValue($instance);
+
+    expect($headers)->toBe(['foo' => 'bar']);
+});


### PR DESCRIPTION
Cherry picked commits from #22 for Pest 3.x

This PR allows adding custom headers to the request through the headers method or PEST_STRESS_TEST_OPTIONS variable. We needed this for authentication.

You can use it like this...

```
$result = stress('example.com')->headers([
    'Authorization' => 'Bearer '. $this->bearerToken,
])

```