### PR TITLE
Use curl to fetch k6 binary with `CURLOPT_FOLLOWLOCATION`

### DIFF
--- a/src/K6.php
+++ b/src/K6.php
@@ -80,9 +80,19 @@ final readonly class K6 implements Stringable
         $url = sprintf(self::K6_URL, self::K6_VERSION, self::K6_VERSION, $os, $arch, $extension);
         $fileName = basename($url);
 
-        if (false === ($binary = file_get_contents($url))) {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+
+        $binary = curl_exec($ch);
+
+        if (false === $binary || 200 !== curl_getinfo($ch, CURLINFO_HTTP_CODE)) {
+            curl_close($ch);
             throw new RuntimeException('Unable to download k6 binary.');
         }
+
+        curl_close($ch);
 
         if (file_put_contents(self::BIN_DIR.$fileName, $binary) === false) {
             throw new RuntimeException('Unable to save k6 binary.');


### PR DESCRIPTION
This pr solves an issue where github redirected while the plugin tried to download the k6 binary by using curl instead of `file_get_contents`.

I had the issue several times while I tried to set up stress testing in my ci workflow. Github always redirected to `https://objects.githubusercontent.com/<...>`.

Please let me now if there is anything I need to adjust.

FYI:
`composer test:types` fails because of missing `./vendor/ergebnis/phpstan-rules/rules.neon` (not required in `composer.json`) and even with it installed it fails with:
```
105    Method Pest\Stressless\Plugin::extractPayload() should return array<string, mixed> but returns array.
```