### PR TITLE
Pass the headers to the stress run

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -48,6 +48,10 @@ final class Plugin implements HandlesArguments
         $run = stress($domain);
 
         foreach ($arguments as $argument) {
+            if (str_starts_with($argument, '--headers=')) {
+                $run->headers($this->extractPayload('headers', $argument));
+            }
+
             if (str_starts_with($argument, '--duration=')) {
                 $run->duration((int) str_replace('--duration=', '', $argument));
             }


### PR DESCRIPTION
### Changed

- Allow passing the `--headers` as a JSON string

---

I'm trying to make a command that runs the stress after login behind CSRF and everything, so I need to pass the headers like that.