### PR TITLE
chore: update k6 to v2.1.0

### DIFF
--- a/src/K6.php
+++ b/src/K6.php
@@ -19,7 +19,7 @@ final readonly class K6 implements Stringable
     /**
      * The version of k6 to download.
      */
-    public const K6_VERSION = 'v0.47.0';
+    public const K6_VERSION = 'v2.1.0';
 
     /**
      * The path where the k6 binary is stored relative to the root


### PR DESCRIPTION
## Summary

- Update the bundled k6 release from `v0.47.0` to `v2.1.0`.
- Keep an exact version pin so Stressless remains reproducible while using a currently maintained k6 release.

## Why

k6 `v0.47.0` was released in October 2023, predates k6 1.0, and is outside Grafana's current support window. The Stressless 5.x branch still downloads that release on first use.

The k6 surface used by Stressless remains compatible with `v2.1.0`: the `run` command, JSON progress output, and `handleSummary` metrics all work without parser or command changes.

## Validation

- `composer test`
- Actual `v2.1.0` binary download and stress run on macOS ARM64 against a controlled local endpoint
- 27 tests passed with 124 assertions; 2 platform-specific tests skipped
- Rector, Pint, and PHPStan passed

References:

- https://github.com/grafana/k6/releases/tag/v0.47.0
- https://github.com/grafana/k6/releases/tag/v2.1.0
- https://grafana.com/docs/k6/latest/reference/versioning-and-stability-guarantees/
